### PR TITLE
Update doc to specify minimum Nexus version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If everything checks out, the bundle for CPAN should be available in the `target
 
 ## Using CPAN With Nexus Repository Manager 3
 
+Requires Nexus Repository Manager version >= 3.8.0
+
 [We have detailed instructions on how to get started here!](docs/CPAN_USER_DOCUMENTATION.md)
 
 ## Installing the plugin


### PR DESCRIPTION
This pull request makes the following changes:
* Update documentation to specify minimum Nexus repository version