### PR TITLE
NEXUS-25906 Extra slash in the URI for asset in community formats

### DIFF
--- a/nexus-repository-cpan/src/main/resources/static/rapture/NX/cpanui/util/CpanRepositoryUrls.js
+++ b/nexus-repository-cpan/src/main/resources/static/rapture/NX/cpanui/util/CpanRepositoryUrls.js
@@ -19,8 +19,10 @@ Ext.define('NX.cpanui.util.CpanRepositoryUrls', {
     'NX.util.Url'
   ]
 }, function(self) {
-	NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cpan', function (assetModel) {
-      var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
-      return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
-    });
+  NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cpan', function(me, assetModel) {
+    var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+    return NX.util.Url.asLink(
+        NX.util.Url.baseUrl + '/repository/' + encodeURIComponent(repositoryName) + '/' + encodeURI(assetName),
+        assetName);
+  });
 });


### PR DESCRIPTION
Fix the code inconsistency with NEXUS internal

This pull request makes the following changes:
* fix parameter of`addRepositoryUrlStrategy` JS method
