### PR TITLE
Revert NEXUS-25906

### DIFF
--- a/nexus-repository-cpan/src/main/resources/static/rapture/NX/cpanui/util/CpanRepositoryUrls.js
+++ b/nexus-repository-cpan/src/main/resources/static/rapture/NX/cpanui/util/CpanRepositoryUrls.js
@@ -19,10 +19,8 @@ Ext.define('NX.cpanui.util.CpanRepositoryUrls', {
     'NX.util.Url'
   ]
 }, function(self) {
-  NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cpan', function(me, assetModel) {
-    var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
-    return NX.util.Url.asLink(
-        NX.util.Url.baseUrl + '/repository/' + encodeURIComponent(repositoryName) + '/' + encodeURI(assetName),
-        assetName);
-  });
+	NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cpan', function (assetModel) {
+      var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+      return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
+    });
 });


### PR DESCRIPTION
Revert changes in [NEXUS-25906](https://issues.sonatype.org/browse/NEXUS-25906).
To apply these changes, the NXRM version should be updated to the 3.29.2-02 or later The corresponding ticket was created [NEXUS-26410](https://issues.sonatype.org/browse/NEXUS-26410)

This pull request makes the following changes:
* revert parameter of`addRepositoryUrlStrategy` JS method
